### PR TITLE
Replace Counter.total() for users with python < 3.10

### DIFF
--- a/obfuscation_detection/utils.py
+++ b/obfuscation_detection/utils.py
@@ -84,13 +84,13 @@ def calc_uncommon_instruction_sequences_score(function):
     # calculate all 3-grams in the function
     function_ngrams = calc_ngrams(function, 3)
     # heuristic to avoid overfitting to small function stubs
-    if function_ngrams.total() < 5:
+    if sum(function_ngrams.values()) < 5:
         return 0.0
     # count the number of ngrams in the function which are not in MOST_COMMON_3GRAMS
     count = sum((value for gram, value in function_ngrams.items()
                 if gram not in MOST_COMMON_3GRAMS))
     # average relative to the amount of ngrams in the functions
-    score = count / function_ngrams.total()
+    score = count / sum(function_ngrams.values())
     return score
 
 


### PR DESCRIPTION
I'm running Binary Ninja on windows 10 and it's got Python 3.9.2, which means the Counter.total() function in `calc_uncommon_instruction_sequences_score()` doesn't work. I've replaced this with `sum(counter.values())` which should do the same thing