### PR TITLE
Implementing the heuristic for MBA expression detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ The heuristic identifies functions which perform an XOR operation with a constan
 * cryptographic implementations
 
 
+### Complex Arithmetic Expressions 
+
+The heuristic identifies functions in which the expressions have more than one arithmetic operation and one boolean operation simultaneously. This way, the heuristic can identify
+
+* mixed-boolean arithmetic obfuscations
+* initialization routine
+* cryptographic implementations
+
+
 ## Contact
 
 For more information, contact [@mr_phrazer](https://twitter.com/mr_phrazer).

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The heuristic identifies functions which perform an XOR operation with a constan
 
 The heuristic identifies functions in which the expressions have more than one arithmetic operation and one boolean operation simultaneously. This way, the heuristic can identify
 
-* mixed-boolean arithmetic obfuscations
+* mixed-boolean arithmetic obfuscation
 * initialization routine
 * cryptographic implementations
 

--- a/__init__.py
+++ b/__init__.py
@@ -8,7 +8,7 @@ from .obfuscation_detection import (detect_obfuscation_bg,
                                     find_most_called_functions_bg,
                                     find_uncommon_instruction_sequences_bg,
                                     find_xor_decryption_loops_bg,
-                                    find_arithmetic_complexity_expressions_bg)
+                                    find_complex_arithmetic_expressions_bg)
 
 PluginCommand.register("Obfuscation Detection\\All",
                        "Detects obfuscated code via heuristics", detect_obfuscation_bg)
@@ -35,4 +35,4 @@ PluginCommand.register("Obfuscation Detection\\XOR Decryption Loops",
                        "Detect functions with XOR decryption loops", find_xor_decryption_loops_bg)
 
 PluginCommand.register("Obfuscation Detection\\Arithmetic Complexity",
-                       "Detect functions with complex arithmetic expressions", find_arithmetic_complexity_expressions_bg)
+                       "Detect functions with complex arithmetic expressions", find_complex_arithmetic_expressions_bg)

--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,8 @@ from .obfuscation_detection import (detect_obfuscation_bg,
                                     find_large_basic_blocks_bg,
                                     find_most_called_functions_bg,
                                     find_uncommon_instruction_sequences_bg,
-                                    find_xor_decryption_loops_bg)
+                                    find_xor_decryption_loops_bg,
+                                    find_mba_expressions_bg)
 
 PluginCommand.register("Obfuscation Detection\\All",
                        "Detects obfuscated code via heuristics", detect_obfuscation_bg)
@@ -32,3 +33,6 @@ PluginCommand.register("Obfuscation Detection\\Most Called Functions",
 
 PluginCommand.register("Obfuscation Detection\\XOR Decryption Loops",
                        "Detect functions with XOR decryption loops", find_xor_decryption_loops_bg)
+
+PluginCommand.register("Obfuscation Detection\\Find MBA",
+                       "Detect functions with MBA expressions", find_mba_expressions_bg)

--- a/__init__.py
+++ b/__init__.py
@@ -8,7 +8,7 @@ from .obfuscation_detection import (detect_obfuscation_bg,
                                     find_most_called_functions_bg,
                                     find_uncommon_instruction_sequences_bg,
                                     find_xor_decryption_loops_bg,
-                                    find_mba_expressions_bg)
+                                    find_arithmetic_complexity_expressions_bg)
 
 PluginCommand.register("Obfuscation Detection\\All",
                        "Detects obfuscated code via heuristics", detect_obfuscation_bg)
@@ -34,5 +34,5 @@ PluginCommand.register("Obfuscation Detection\\Most Called Functions",
 PluginCommand.register("Obfuscation Detection\\XOR Decryption Loops",
                        "Detect functions with XOR decryption loops", find_xor_decryption_loops_bg)
 
-PluginCommand.register("Obfuscation Detection\\Find MBA",
-                       "Detect functions with MBA expressions", find_mba_expressions_bg)
+PluginCommand.register("Obfuscation Detection\\Arithmetic Complexity",
+                       "Detect functions with complex arithmetic expressions", find_arithmetic_complexity_expressions_bg)

--- a/obfuscation_detection/__init__.py
+++ b/obfuscation_detection/__init__.py
@@ -61,9 +61,9 @@ def detect_obfuscation_bg(bv):
     background_task.start()
 
 
-def find_mba_expressions_bg(bv):
+def find_arithmetic_complexity_expressions_bg(bv):
     background_task = BGTask(
-        bv, "Detecting MBA expressions in functions", find_mba_expressions)
+        bv, "Detect functions with complex arithmetic expressions", find_arithmetic_complexity_expressions)
     background_task.start()
 
 def detect_obfuscation(bv):
@@ -89,4 +89,4 @@ def detect_obfuscation(bv):
     find_xor_decryption_loops(bv)
 
     # find expressions that include boolean and arithmetic operations
-    find_mba_expressions(bv)
+    find_arithmetic_complexity_expressions(bv)

--- a/obfuscation_detection/__init__.py
+++ b/obfuscation_detection/__init__.py
@@ -61,6 +61,11 @@ def detect_obfuscation_bg(bv):
     background_task.start()
 
 
+def find_mba_expressions_bg(bv):
+    background_task = BGTask(
+        bv, "Detecting MBA expressions in functions", find_mba_expressions)
+    background_task.start()
+
 def detect_obfuscation(bv):
     # find flattened functions
     find_flattened_functions(bv)
@@ -82,3 +87,6 @@ def detect_obfuscation(bv):
 
     # find functions with xor decryption loops
     find_xor_decryption_loops(bv)
+
+    # find expressions that include boolean and arithmetic operations
+    find_mba_expressions(bv)

--- a/obfuscation_detection/__init__.py
+++ b/obfuscation_detection/__init__.py
@@ -61,9 +61,9 @@ def detect_obfuscation_bg(bv):
     background_task.start()
 
 
-def find_arithmetic_complexity_expressions_bg(bv):
+def find_complex_arithmetic_expressions_bg(bv):
     background_task = BGTask(
-        bv, "Detect functions with complex arithmetic expressions", find_arithmetic_complexity_expressions)
+        bv, "Detect functions with complex arithmetic expressions", find_complex_arithmetic_expressions)
     background_task.start()
 
 def detect_obfuscation(bv):
@@ -89,4 +89,4 @@ def detect_obfuscation(bv):
     find_xor_decryption_loops(bv)
 
     # find expressions that include boolean and arithmetic operations
-    find_arithmetic_complexity_expressions(bv)
+    find_complex_arithmetic_expressions(bv)

--- a/obfuscation_detection/heuristics.py
+++ b/obfuscation_detection/heuristics.py
@@ -123,40 +123,11 @@ def find_xor_decryption_loops(bv):
             print(
                 f"Function {hex(f.start)} ({f.name}) contains a XOR decryption loop with a constant.")
 
-arithmetic_op = [HighLevelILOperation.HLIL_ADD, HighLevelILOperation.HLIL_NEG, HighLevelILOperation.HLIL_SUB, HighLevelILOperation.HLIL_MUL, HighLevelILOperation.HLIL_DIVS, HighLevelILOperation.HLIL_MODS]
-boolean_op = [HighLevelILOperation.HLIL_NOT, HighLevelILOperation.HLIL_AND, HighLevelILOperation.HLIL_OR, HighLevelILOperation.HLIL_XOR]
-arithmetic_counter = 0
-boolean_counter = 0
-
-def traverse_HLIL(il, ident):
-    global arithmetic_counter, boolean_counter
-    if isinstance(il, highlevelil.HighLevelILInstruction):
-        if il.operation in arithmetic_op:
-            arithmetic_counter += 1
-
-        if il.operation in boolean_op:
-            boolean_counter += 1
-
-        for o in il.operands:
-            traverse_HLIL(o, ident+1)
-
-def find_mba_expressions(bv):
+def find_arithmetic_complexity_expressions(bv):
     print("=" * 80)
-    print("Functions that might have MBA expressions:")
-    global boolean_counter, arithmetic_counter
-    # iterate through functions 
-    for f in bv.functions:
-        instr_mba = 0
-        if f.hlil is not None:
-            # iterate through HIL instructions via AST
-            for ins in f.hlil.root:
-                # reset the counters per each instruction
-                boolean_counter = 0
-                arithmetic_counter = 0
-                traverse_HLIL(ins, 0)
-                # if an expression has a boolean operation and a arithmetic operation, it's probably an MBA expression
-                if boolean_counter >= 1 and arithmetic_counter >= 1:
-                    instr_mba += 1
-            
-            if instr_mba != 0:
-                print(f"Function {hex(f.start)} ({f.name}) has {instr_mba} instructions that resemble MBA expressions")
+    print("Functions with complex arithmetic expressions:")
+    
+    for f, score in get_top_10_functions(bv.functions, lambda f: calculate_arithmetic_complexity_expressions(f)):
+        if score != 0:
+            print(
+                f"Function {hex(f.start)} ({(f.name)}) has {score} instruction that seem to be complex arithmetic expressions.")

--- a/obfuscation_detection/heuristics.py
+++ b/obfuscation_detection/heuristics.py
@@ -122,3 +122,41 @@ def find_xor_decryption_loops(bv):
         if contains_xor_decryption_loop(bv, f):
             print(
                 f"Function {hex(f.start)} ({f.name}) contains a XOR decryption loop with a constant.")
+
+arithmetic_op = [HighLevelILOperation.HLIL_ADD, HighLevelILOperation.HLIL_NEG, HighLevelILOperation.HLIL_SUB, HighLevelILOperation.HLIL_MUL, HighLevelILOperation.HLIL_DIVS, HighLevelILOperation.HLIL_MODS]
+boolean_op = [HighLevelILOperation.HLIL_NOT, HighLevelILOperation.HLIL_AND, HighLevelILOperation.HLIL_OR, HighLevelILOperation.HLIL_XOR]
+arithmetic_counter = 0
+boolean_counter = 0
+
+def traverse_HLIL(il, ident):
+    global arithmetic_counter, boolean_counter
+    if isinstance(il, highlevelil.HighLevelILInstruction):
+        if il.operation in arithmetic_op:
+            arithmetic_counter += 1
+
+        if il.operation in boolean_op:
+            boolean_counter += 1
+
+        for o in il.operands:
+            traverse_HLIL(o, ident+1)
+
+def find_mba_expressions(bv):
+    print("=" * 80)
+    print("Functions that might have MBA expressions:")
+    global boolean_counter, arithmetic_counter
+    # iterate through functions 
+    for f in bv.functions:
+        instr_mba = 0
+        if f.hlil is not None:
+            # iterate through HIL instructions via AST
+            for ins in f.hlil.root:
+                # reset the counters per each instruction
+                boolean_counter = 0
+                arithmetic_counter = 0
+                traverse_HLIL(ins, 0)
+                # if an expression has a boolean operation and a arithmetic operation, it's probably an MBA expression
+                if boolean_counter >= 1 and arithmetic_counter >= 1:
+                    instr_mba += 1
+            
+            if instr_mba != 0:
+                print(f"Function {hex(f.start)} ({f.name}) has {instr_mba} instructions that resemble MBA expressions")

--- a/obfuscation_detection/heuristics.py
+++ b/obfuscation_detection/heuristics.py
@@ -123,11 +123,15 @@ def find_xor_decryption_loops(bv):
             print(
                 f"Function {hex(f.start)} ({f.name}) contains a XOR decryption loop with a constant.")
 
-def find_arithmetic_complexity_expressions(bv):
+def find_complex_arithmetic_expressions(bv):
+    """
+    Heuristic to identify complex (mixed) boolean expressions inspired by gooMBA:
+    https://github.com/HexRaysSA/goomba
+    """
     print("=" * 80)
     print("Functions with complex arithmetic expressions:")
     
-    for f, score in get_top_10_functions(bv.functions, lambda f: calculate_arithmetic_complexity_expressions(f)):
+    for f, score in get_top_10_functions(bv.functions, lambda f: calculate_complex_arithmetic_expressions(f)):
         if score != 0:
             print(
                 f"Function {hex(f.start)} ({(f.name)}) has {score} instruction that seem to be complex arithmetic expressions.")

--- a/obfuscation_detection/utils.py
+++ b/obfuscation_detection/utils.py
@@ -6,6 +6,7 @@ from binaryninja.enums import LowLevelILOperation, HighLevelILOperation
 
 from .ngrams import determine_ngram_database
 
+
 # initialize operations
 ARITHMETIC_OPERATION = set([
     HighLevelILOperation.HLIL_ADD,
@@ -24,6 +25,7 @@ BOOLEAN_OPERATION = set([
     HighLevelILOperation.HLIL_LSR,
     HighLevelILOperation.HLIL_LSL
 ])
+
 
 def calc_flattening_score(function):
     score = 0.0

--- a/obfuscation_detection/utils.py
+++ b/obfuscation_detection/utils.py
@@ -6,6 +6,24 @@ from binaryninja.enums import LowLevelILOperation, HighLevelILOperation
 
 from .ngrams import determine_ngram_database
 
+# initialize operations
+ARITHMETIC_OPERATION = set([
+    HighLevelILOperation.HLIL_ADD,
+    HighLevelILOperation.HLIL_NEG,
+    HighLevelILOperation.HLIL_SUB,
+    HighLevelILOperation.HLIL_MUL,
+    HighLevelILOperation.HLIL_DIVS,
+    HighLevelILOperation.HLIL_MODS,
+])
+
+BOOLEAN_OPERATION = set([
+    HighLevelILOperation.HLIL_NOT,
+    HighLevelILOperation.HLIL_AND,
+    HighLevelILOperation.HLIL_OR,
+    HighLevelILOperation.HLIL_XOR,
+    HighLevelILOperation.HLIL_LSR,
+    HighLevelILOperation.HLIL_LSL
+])
 
 def calc_flattening_score(function):
     score = 0.0
@@ -163,42 +181,47 @@ def calc_uncommon_instruction_sequences_score(function):
     score = count / sum(function_ngrams.values())
     return score
 
-arithmetic_op = set([HighLevelILOperation.HLIL_ADD, HighLevelILOperation.HLIL_NEG, HighLevelILOperation.HLIL_SUB, HighLevelILOperation.HLIL_MUL, HighLevelILOperation.HLIL_DIVS, HighLevelILOperation.HLIL_MODS])
-boolean_op = set([HighLevelILOperation.HLIL_NOT, HighLevelILOperation.HLIL_AND, HighLevelILOperation.HLIL_OR, HighLevelILOperation.HLIL_XOR])
-arithmetic_counter = 0
-boolean_counter = 0
 
-def traverse_HLIL(il):
-    global arithmetic_counter, boolean_counter
-    if isinstance(il, highlevelil.HighLevelILInstruction):
-        if il.operation in arithmetic_op:
-            arithmetic_counter += 1
+def uses_mixed_boolean_arithmetic(hlil_instruction):
+    # initialize
+    global ARITHMETIC_OPERATION, BOOLEAN_OPERATION
+    uses_boolean = False
+    uses_arithmetic = False
+    ins_stack = [hlil_instruction]
 
-        if il.operation in boolean_op:
-            boolean_counter += 1
+    # worklist algorithm
+    while len(ins_stack) != 0:
+        instruction = ins_stack.pop()
+        # check if boolean or arithmetic operation
+        if isinstance(instruction, highlevelil.HighLevelILInstruction):
+            # arithmetic operation
+            if instruction.operation in ARITHMETIC_OPERATION:
+                uses_arithmetic = True
+            # boolean operation
+            elif instruction.operation in BOOLEAN_OPERATION:
+                uses_boolean = True
+            # mixed boolean arithmetic
+            if uses_boolean and uses_arithmetic:
+                return True
+            # add operands to worklist
+            for op in instruction.operands:
+                ins_stack.append(op)
+    return False
 
-        for o in il.operands:
-            traverse_HLIL(o)
 
-def calculate_arithmetic_complexity_expressions(function):
-    # check if the hlil AST has been generated for the function
-    if function.analysis_skipped: return 0
-
-    global boolean_counter, arithmetic_counter
-
+def calculate_complex_arithmetic_expressions(function):
+    # check if the hlil has been generated for the function
+    if function.hlil_if_available == None:
+        return 0
+    # init mba counter
     instr_mba = 0
+    # iterate hlil instructions
+    for ins in function.hlil_if_available.instructions:
+        # if an expression has a boolean and an arithmetic operation, the expression has some arithmetic complexity
+        if uses_mixed_boolean_arithmetic(ins):
+            instr_mba += 1
+    return instr_mba           
 
-    if function.hlil is not None:
-        for ins in function.hlil.root:
-            # reset counters
-            boolean_counter = 0
-            arithmetic_counter = 0
-            traverse_HLIL(ins)
-            # if an expression has a boolean operation and a arithmetic operation, the expression has some arithmetic complexity
-            if boolean_counter >= 1 and arithmetic_counter >= 1:
-                instr_mba += 1
-
-    return instr_mba            
 
 def get_top_10_functions(functions, scoring_function):
     # sort functions by scoring function


### PR DESCRIPTION
The heuristic simply iterates the AST of HLIL instructions and updates two counters (arithmetic op counters and boolean op counters). For each instruction, the heuristic counts how many arithmetic operations there are and how many boolean operations there are. If the two counters are >= 1, then we have an MBA expression. 

The heuristic has some limits due to computation needed for HLIL lifting. Since HLIL lifting is not actually done for large functions, the heuristic might miss the most interesting functions for mba expressions. 
